### PR TITLE
Dockerisation de APIVIZ

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+app/frontend/node_modules
+venv
+.git
+nginx

--- a/Dockerfile.backend-gunicorn
+++ b/Dockerfile.backend-gunicorn
@@ -1,0 +1,12 @@
+FROM python:2.7
+
+WORKDIR /app_in_docker
+
+COPY requirements.txt /app_in_docker/requirements.txt
+
+RUN pip install -r requirements.txt
+
+COPY . /app_in_docker
+
+ENTRYPOINT ["gunicorn"]
+CMD ["wsgi-local-docker:app","--bind","0.0.0.0:8100"]

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,11 @@
+FROM node:8
+
+WORKDIR /app_in_docker
+
+COPY /app .
+
+WORKDIR /app_in_docker/frontend
+# cache package.json and node_modules to speed up builds
+RUN npm install
+
+CMD ["npm","run","build"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+export APP=apiviz
+export DC_PREFIX= $(shell pwd)/docker-compose
+export APP_PATH := $(shell pwd)
+export BACKEND=${APP_PATH}
+export FRONTEND=${APP_PATH}
+
+#other variable definition
+DC    := 'docker-compose'
+
+frontend: network
+	${DC} -f ${DC_PREFIX}-frontend.yml up --build -d
+
+frontend-stop:
+	${DC} -f ${DC_PREFIX}-frontend.yml down
+
+network-stop:
+	docker network rm ${APP}
+
+network:
+	@docker network create ${APP} 2> /dev/null; true
+
+backend-gunicorn:
+	${DC} -f ${DC_PREFIX}-backend-gunicorn.yml up --build -d
+
+backend-gunicorn-stop:
+	${DC} -f ${DC_PREFIX}-backend-gunicorn.yml down
+
+up: network frontend backend-gunicorn
+
+down: backend-gunicorn-stop frontend-stop network-stop
+
+restart: down up

--- a/docker-compose-backend-gunicorn.yml
+++ b/docker-compose-backend-gunicorn.yml
@@ -1,0 +1,10 @@
+version: '2.1'
+services:
+  backend:
+    container_name: ${APP}-backend
+    build:
+      context: ${BACKEND}
+      dockerfile: Dockerfile.backend-gunicorn
+    restart: always
+    ports:
+      - "8100:8100"

--- a/docker-compose-frontend.yml
+++ b/docker-compose-frontend.yml
@@ -1,0 +1,9 @@
+version: '2.1'
+services:
+  frontend:
+    container_name: ${APP}-frontend
+    build:
+      context: ${FRONTEND}
+      dockerfile: Dockerfile.frontend
+    volumes:
+      - ./app/static:/app_in_docker/static

--- a/wsgi-local-docker.py
+++ b/wsgi-local-docker.py
@@ -1,0 +1,36 @@
+# -*- encoding: utf-8 -*-
+
+"""
+wsgi file to run app in production mode from gunicorn
+"""
+
+import os, sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+os.environ['FLASK_CONFIGURATION'] = "default"
+
+from app import app, log_app
+
+
+if __name__ == '__main__':
+	"""
+	runner for the CIS front Flask app
+	- warning : gets most of its variables at start from environment variables
+
+	in command line just type :
+	"python wsgi.py"
+	or
+	"gunicorn --bind 0.0.0.0:8100 --workers=1 wsgi:app" for instance
+
+	"""
+
+	# set environment variable to set config later in config_app.config_env.py
+
+	print "= "*25
+	print "= = = WSGI / RERUN FLASK APP = = ="
+	log_app.info
+	print "= "*25
+
+	# simple flask runner
+	app.run()


### PR DESCRIPTION
Dockerisation de APIVIZ … fait sur MacOS X, docker 18, compose 1.3

Restent a faire:
- MONGO_URI variablisier en fonciton des situations (sur un ordi via 
docker = host.docker.internal, sur un server, sur un server sans docker)
- test sur server du deploiement avec Docker
- decouper frontend et backend
- WSGI a ecrire pour toutes les situations possibles, et ne pas oublier 
de les reporter dans les DockerFile correspondants
- verifer que les build successifs de Docker sur server ne prennent pas 
trop de place -> mettre en place un "docker systemm prune" si jamais ca 
arrive